### PR TITLE
Improve rendering speed / performance

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -20,7 +20,7 @@ app.on('ready', () => {
     resizable: true,
     frame: process.platform !== 'darwin',
     skipTaskbar: process.platform === 'darwin',
-    autoHideMenuBar: process.platform === 'darwin',
+    autoHideMenuBar: process.platform !== 'darwin',
     webPreferences: { zoomFactor: 1.0, nodeIntegration: true, backgroundThrottling: false }
   })
 

--- a/desktop/sources/scripts/components/scenenode.js
+++ b/desktop/sources/scripts/components/scenenode.js
@@ -111,36 +111,36 @@ class SceneNode {
   }
 
   whenInherit () {
-    for (let node of this.children) {
-      node.whenInherit()
+    for( let i = 0; i < this.children.length; i++ ) {
+      this.children[i].whenInherit()
     }
   }
 
   whenStart () {
     // assertArgs(arguments, 0);
-    for (let node of this.children) {
-      node.whenStart()
+    for( let i = 0; i < this.children.length; i++ ) {
+      this.children[i].whenStart()
     }
   }
 
   whenSecond () {
     // assertArgs(arguments, 0);
-    for (let node of this.children) {
-      node.whenSecond()
+    for( let i = 0; i < this.children.length; i++ ) {
+      this.children[i].whenSecond()
     }
   }
 
   whenRenderer () {
     // assertArgs(arguments, 0);
-    for (let node of this.children) {
-      node.whenRenderer()
+    for( let i = 0; i < this.children.length; i++ ) {
+      this.children[i].whenRenderer()
     }
   }
 
   whenResize () {
     // assertArgs(arguments, 0);
-    for (let node of this.children) {
-      node.whenResize()
+    for( let i = 0; i < this.children.length; i++ ) {
+      this.children[i].whenResize()
     }
   }
 

--- a/desktop/sources/scripts/components/scenewire.js
+++ b/desktop/sources/scripts/components/scenewire.js
@@ -89,19 +89,35 @@ class SceneWire extends Empty {
     this.updateSegments()
   }
 
+  startAnimation() {
+    if( !verreciel.wires.includes( this ) ) {
+      verreciel.wires.push( this )
+    }
+  }
+
+  stopAnimation() {
+    var index = verreciel.wires.indexOf( this )
+    if( ~index ) {
+      verreciel.wires.splice( index, 1 )
+    }
+  }
+
   animate () {
+
     let rand = Math.random()
     let delta = verreciel.game.time - this.lastGameTime
+
     this.lastGameTime = verreciel.game.time
     this.time += rand * rand * delta
+
     if (
       this.isEnabled == false ||
       this.endB == null ||
       this.endA.equals(this.endB)
     ) {
-      return
+      this.stopAnimation()
     }
-    requestAnimationFrame(this.animate.bind(this))
+
   }
 
   updateEnds (
@@ -121,7 +137,7 @@ class SceneWire extends Empty {
 
     if (reset == true) {
       this.phase = Math.random() * Math.PI * 2
-      this.animate()
+      this.startAnimation()
     }
 
     this.updateSegments()

--- a/desktop/sources/scripts/core/game.js
+++ b/desktop/sources/scripts/core/game.js
@@ -6,6 +6,7 @@ class Game {
     // assertArgs(arguments, 0);
     console.info('^ Game | Init')
     this.time = 0
+    this.seconds = 0
     this.gameSpeed = 1
     if (DEBUG_LOG_GHOST) {
       this.gameSpeed = 5
@@ -15,8 +16,6 @@ class Game {
   whenStart (jump_mission) {
     // assertArgs(arguments, 0);
     console.info('+ Game | Start')
-    setTimeout(this.onTic.bind(this), 50)
-    setTimeout(this.whenSecond.bind(this), 1000 / this.gameSpeed)
     if (JUMP_MISSION) {
       this.load(jump_mission)
       return
@@ -77,16 +76,15 @@ class Game {
     this.load(0)
   }
 
-  whenSecond () {
+  tick ( delta ) {
     // assertArgs(arguments, 0);
-    setTimeout(this.whenSecond.bind(this), 1000 / this.gameSpeed)
-    verreciel.capsule.whenSecond()
-    verreciel.missions.refresh()
-  }
-
-  onTic () {
-    // assertArgs(arguments, 0);
-    setTimeout(this.onTic.bind(this), 50)
     this.time += this.gameSpeed
+    this.seconds += delta
+
+    if( this.seconds > ( 1 / this.gameSpeed )) {
+      this.seconds = 0
+      verreciel.capsule.whenSecond()
+      verreciel.missions.refresh()
+    }
   }
 }

--- a/desktop/sources/scripts/core/music.js
+++ b/desktop/sources/scripts/core/music.js
@@ -12,11 +12,9 @@ class Music {
     this.analyser = this.context.createAnalyser()
     this.analyser.connect(this.context.destination)
     this.data = new Uint8Array(this.analyser.frequencyBinCount)
-    requestAnimationFrame(this.updateData.bind(this))
   }
 
   updateData () {
-    requestAnimationFrame(this.updateData.bind(this))
     this.analyser.getByteFrequencyData(this.data)
     const length = this.data.length
     let count = 0


### PR DESCRIPTION
I started playing Verreciel again the other day... had some noticeable stuttering, and the controls didn't seem to be responding as quickly & smoothly as I had anticipated. Since I wanted to take my mind off of other things anyway, I decided to dig in, and see what I could find :)

**Rendering speed/performance:**

- Consolidate all requested animation frames into the main render loop
- Remove `setTimeout()`s, and couple those mechanisms to the main render loop as well
- Remove inline `fn.bind(this)`, as this can be done once in the constructor
- Use a high resolution timer for frame time deltas through `THREE.Clock()`
- Update all animations and wires through the main render loop
- Increase `verreciel.fps` from 40 to 60, to match `requestAnimationFrame()` intervals

**Performance of .when{Inherit,Start,Second,Renderer,...}:**

Doing away with implicitly created iterators speeds things up considerably (these methods suddenly become invisible in performance profiles)
